### PR TITLE
Fixed points that didn't work

### DIFF
--- a/gyazo.mjs
+++ b/gyazo.mjs
@@ -1,4 +1,6 @@
 import request from "request";
+import * as dotenv from 'dotenv'
+dotenv.config();
 
 export function image(query = {}) {
   return new Promise((resolve, reject) => {

--- a/makeJson.mjs
+++ b/makeJson.mjs
@@ -2,6 +2,10 @@ import fs from "fs/promises";
 import path from "path";
 import pdfjs from "pdfjs-dist/legacy/build/pdf.js";
 import nodeCanvas from "canvas";
+
+import * as dotenv from 'dotenv'
+dotenv.config();
+
 import Gyazo from "gyazo-api";
 const client = new Gyazo(process.env.GYAZO_TOKEN);
 

--- a/makeJson.mjs
+++ b/makeJson.mjs
@@ -45,7 +45,7 @@ const json = { pages: [] };
 try {
   await fs.stat(`out/${filename}`);
 } catch {
-  fs.mkdir(`out/${filename}`);
+  await fs.mkdir(`out/${filename}`, { recursive: true });
 }
 
 const keta = pages.length.toString().length;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "pdfjs-dist": "^2.8.335"
       },
       "devDependencies": {
+        "dotenv": "^10.0.0",
         "prettier": "^2.3.2"
       }
     },
@@ -551,6 +552,15 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -2222,6 +2232,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+    },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "pdfjs-dist": "^2.8.335"
   },
   "devDependencies": {
+    "dotenv": "^10.0.0",
     "prettier": "^2.3.2"
   }
 }


### PR DESCRIPTION
- The `.env` could not be read without dotenv.
- An error occurred if the out directory did not exist.

